### PR TITLE
cxx bindings: Remove  Suppress warnings Macro

### DIFF
--- a/bindings/cxx/include/libsigrokcxx/libsigrokcxx.hpp
+++ b/bindings/cxx/include/libsigrokcxx/libsigrokcxx.hpp
@@ -71,13 +71,7 @@ raised, which provides access to the error code and description.
 #define LIBSIGROKCXX_HPP
 
 #include <libsigrok/libsigrok.h>
-
-/* Suppress warnings due to glibmm's use of std::auto_ptr<> in a public
- * header file. To be removed once glibmm is fixed. */
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 #include <glibmm.h>
-G_GNUC_END_IGNORE_DEPRECATIONS
-
 #include <stdexcept>
 #include <memory>
 #include <vector>


### PR DESCRIPTION
Hi I found Suppress warnings Macro from libsigrok/bindings/cxx/include/libsigrokcxx/
But Glibmm no longer use of auto_ptr.
(https://github.com/GNOME/glibmm/commit/0b8237dd0b77a1e2d031256bacd97e13193039bb)
Therefore Cleaned up macroline.